### PR TITLE
attempt to fix group membership

### DIFF
--- a/lib/puppet/parser/functions/user_is_group_member.rb
+++ b/lib/puppet/parser/functions/user_is_group_member.rb
@@ -1,0 +1,38 @@
+# take a user name and a hash of user groups
+# find which groups that user is a member of
+# also expand any users listed with an @ symbol
+# at the start of the user name - this will be a
+# ref to a group
+
+module Puppet::Parser::Functions
+  newfunction(:user_is_group_member, :type => :rvalue, :doc => <<-EOS
+      Returns an array of groups a user is a member of
+    EOS
+  ) do |args|
+    raise(Puppet::ArgumentError, "user_is_group_member(): Wrong number of arguments given") if args.size != 2
+    raise(Puppet::ArgumentError, "user_is_group_member(): First parameter must be a string") if args[0].class != String
+    raise(Puppet::ArgumentError, "user_is_group_member(): Second parameter must be a hash") if args[1].class != Hash
+
+    user = args[0]
+    usergroups = args[1]
+    groups = []
+
+    usergroups.each do |groupname, properties|
+      if properties.class == Hash and properties.has_key?('members')
+        if properties['members'].include? user
+          groups << groupname
+        end
+        properties['members'].each do |member|
+          if member.start_with?('@')
+            group_member = member.tr('@','')
+            if usergroups[group_member]['members'].include? user
+              groups << groupname
+            end
+          end
+        end
+      end
+    end
+    #Puppet.notice("user #{user} has groups: " + groups.to_s)
+    groups
+  end
+end

--- a/manifests/authorized_key.pp
+++ b/manifests/authorized_key.pp
@@ -19,7 +19,7 @@ define accounts::authorized_key(
     }
     ensure_resource(
       accounts::authorized_key,
-      suffix($::accounts::usergroups[$1], "-on-${account}"),
+      suffix($::accounts::usergroups[$1]['members'], "-on-${account}"),
       {
         ensure                   => $ensure,
         options                  => $options,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,5 @@
 # See README.md for details.
 class accounts(
-  $groups                   = {},
   $groups_membership        = undef,
   $ssh_keys                 = {},
   $users                    = {},
@@ -16,7 +15,11 @@ class accounts(
 ) {
   include ::accounts::config
 
-  create_resources(group, $groups)
+  # create any groups found in the usergroups hash
+  group {
+    keys($usergroups):
+      ensure => present,
+  }
 
   create_resources(accounts::account, $accounts)
 


### PR DESCRIPTION
@sysadminsemantics noticed that the accounts module was not creating user groups correctly on new builds, so we now have a usergroups hash in hiera which contains group members - this gets used by the this module to correctly create users with the correct groups

With: https://github.com/BrandwatchLtd/puppetserver-environments/pull/874

note: we are now explicitly creating any groups found in the usergroups hash - it simplifies the group setup and means they exist before any users become members of those groups